### PR TITLE
Add readout panel example

### DIFF
--- a/source/card_example.hpp
+++ b/source/card_example.hpp
@@ -12,16 +12,16 @@ void card_example( emp::web::Document& doc ) {
   emp::prefab::Card card_ex("INIT_CLOSED");
   doc << card_ex;
   card_ex.AddHeaderContent("<h3>Card</h3>");
-  card_ex.AddBodyContent("<h3>Live Demo:</h3><hr>");
+  card_ex << "<h3>Live Demo:</h3><hr>";
   // Collapsible Card, default open
   emp::prefab::Card openCard("INIT_OPEN");
-  card_ex.AddBodyContent(openCard);
+  card_ex << openCard;
   // Header content with bootstrap link properties
-  openCard.AddHeaderContent("Open card");
-  openCard.AddBodyContent("Open body content <br> Glyphs <br> Linked title");
+  openCard << "Open card";
+  openCard << "Open body content <br> Glyphs <br> Linked title";
   openCard.SetCSS("margin-bottom", "15px");
 
-  card_ex.AddBodyContent("<br><h3>Code:</h3><hr>");
+  card_ex << "<br><h3>Code:</h3><hr>";
 
   const std::string card_code =
     R"(
@@ -35,13 +35,13 @@ void card_example( emp::web::Document& doc ) {
         doc << openCard;
 
         openCard.AddHeaderContent("Open card");
-        openCard.AddBodyContent("Open body content <br> Glyphs <br> Linked title");
+        openCard << "Open body content <br> Glyphs <br> Linked title";
 
         openCard.SetCSS("margin-bottom", "15px");
       }
     )";
 
   emp::prefab::CodeBlock card_code_block(card_code, "c++");
-  card_ex.AddBodyContent(card_code_block);
+  card_ex << card_code_block;
 
 }

--- a/source/code_block_example.hpp
+++ b/source/code_block_example.hpp
@@ -12,7 +12,7 @@ void code_block_example( emp::web::Document& doc ) {
   emp::prefab::Card code_block_ex("INIT_CLOSED");
   doc << code_block_ex;
   code_block_ex.AddHeaderContent("<h3>Code Block </h1");
-  code_block_ex.AddBodyContent("<h3>Live Demo:</h3><hr>");
+  code_block_ex << "<h3>Live Demo:</h3><hr>";
 
   const std::string code_block_code =
     R"(
@@ -34,18 +34,18 @@ void code_block_example( emp::web::Document& doc ) {
       )";
 
   emp::prefab::CodeBlock code_block_block(code_block_code, "c++");
-  code_block_ex.AddBodyContent(code_block_block);
+  code_block_ex << code_block_block ;
 
-  code_block_ex.AddBodyContent("<p>This code bock is built using the code displayed within.</p>");
+  code_block_ex << "<p>This code bock is built using the code displayed within.</p>";
 
-  code_block_ex.AddBodyContent("<p>Add to HTML file</p>");
+  code_block_ex << "<p>Add to HTML file</p>";
   const std::string cb_html =
     R"(
 
     )";
   emp::prefab::CodeBlock cb_html_block(cb_html, "html");
-  code_block_ex.AddBodyContent(cb_html_block);
+  code_block_ex << cb_html_block;
 
-  code_block_ex.AddBodyContent("<p>NOTE: A list of all languages supported by HighlightJS can be found <a href=\"https://highlightjs.org/static/demo/\" target=\"_blank\">here</a>");
+  code_block_ex << "<p>NOTE: A list of all languages supported by HighlightJS can be found <a href=\"https://highlightjs.org/static/demo/\" target=\"_blank\">here</a>";
 
 }

--- a/source/collapse_example.hpp
+++ b/source/collapse_example.hpp
@@ -15,7 +15,7 @@ void collapse_example( emp::web::Document& doc ) {
   emp::prefab::Card collapse_ex("INIT_CLOSED");
   doc << collapse_ex;
   collapse_ex.AddHeaderContent("<h3>Collapse</h3>");
-  collapse_ex.AddBodyContent("<h3>Live Demo:</h3><hr>");
+  collapse_ex << "<h3>Live Demo:</h3><hr>";
   emp::prefab::CommentBox box1;
   box1.AddContent("<h3>Box 1</h3>");
   emp::web::Div btn1;
@@ -38,13 +38,13 @@ void collapse_example( emp::web::Document& doc ) {
   collapse1.AddController(btn3, true);
   collapse2.AddController(collapse1.GetControllerDiv(1), true);
 
-  collapse_ex.AddBodyContent(collapse1.GetControllerDiv(0));
-  collapse_ex.AddBodyContent(collapse1.GetTargetDiv(0));
-  collapse_ex.AddBodyContent(collapse2.GetControllerDiv(0));
-  collapse_ex.AddBodyContent(collapse2.GetTargetDiv(0));
-  collapse_ex.AddBodyContent(collapse1.GetControllerDiv(1));
+  collapse_ex << collapse1.GetControllerDiv(0);
+  collapse_ex << collapse1.GetTargetDiv(0);
+  collapse_ex << collapse2.GetControllerDiv(0);
+  collapse_ex << collapse2.GetTargetDiv(0);
+  collapse_ex << collapse1.GetControllerDiv(1);
 
-  collapse_ex.AddBodyContent("<br><br><h3>Code:</h3><hr>");
+  collapse_ex << "<br><br><h3>Code:</h3><hr>";
 
   const std::string collapse_code =
     R"(
@@ -88,6 +88,6 @@ void collapse_example( emp::web::Document& doc ) {
     )";
 
   emp::prefab::CodeBlock collapse_code_block(collapse_code, "c++");
-  collapse_ex.AddBodyContent(collapse_code_block);
+  collapse_ex << (collapse_code_block);
 
 }

--- a/source/comment_box_example.hpp
+++ b/source/comment_box_example.hpp
@@ -13,14 +13,14 @@ void comment_box_example( emp::web::Document& doc ) {
   emp::prefab::Card comment_box_ex("INIT_CLOSED");
   doc << comment_box_ex;
   comment_box_ex.AddHeaderContent("<h3>Comment Box</h3>");
-  comment_box_ex.AddBodyContent("<h3>Live Demo:</h3><hr>");
+  comment_box_ex << "<h3>Live Demo:</h3><hr>";
   emp::prefab::CommentBox box;
-  comment_box_ex.AddBodyContent(box);
+  comment_box_ex << box;
   emp::web::Div title("desktop_content");
   title << "<p>Content for comment box</p>";
   box.AddContent(title);
 
-  comment_box_ex.AddBodyContent("<br><h3>Code:</h3><hr>");
+  comment_box_ex << "<br><h3>Code:</h3><hr>";
 
   const std::string comment_box_code =
     R"(
@@ -40,6 +40,6 @@ void comment_box_example( emp::web::Document& doc ) {
     )";
 
   emp::prefab::CodeBlock comment_box_code_block(comment_box_code, "c++");
-  comment_box_ex.AddBodyContent(comment_box_code_block);
+  comment_box_ex << comment_box_code_block;
 
 }

--- a/source/config_panel_example.hpp
+++ b/source/config_panel_example.hpp
@@ -11,17 +11,13 @@
 
 SampleConfig cfg;
 
-// TODO: Find a way to initialize config panels within main()
-// Issue #366 (https://github.com/devosoft/Empirical/issues/366)
-emp::prefab::ConfigPanel config_panel(cfg);
-
 void config_panel_example( emp::web::Document& doc ) {
 
   // ------ Config Panel Example ------
   emp::prefab::Card config_panel_ex("INIT_CLOSED");
   doc << config_panel_ex;
   config_panel_ex.AddHeaderContent("<h3>Config Panel</h3>");
-  config_panel_ex.AddBodyContent("<h3>Live Demo:</h3><hr>");
+  config_panel_ex << "<h3>Live Demo:</h3><hr>";
 
   // apply configuration query params and config files to Config
   auto specs = emp::ArgManager::make_builtin_specs(&cfg);
@@ -29,12 +25,12 @@ void config_panel_example( emp::web::Document& doc ) {
   // cfg.Read("config.cfg");
   am.UseCallbacks();
   if (am.HasUnused()) std::exit(EXIT_FAILURE);
+  emp::prefab::ConfigPanel config_panel(cfg);
 
   // setup configuration panel
-  config_panel.Setup();
-  config_panel_ex.AddBodyContent(config_panel.GetConfigPanelDiv());
+  config_panel_ex << config_panel;
 
-  config_panel_ex.AddBodyContent("<br><h3>Code:</h3><hr>");
+  config_panel_ex << "<br><h3>Code:</h3><hr>";
 
   const std::string cp_code =
     R"(
@@ -48,7 +44,6 @@ void config_panel_example( emp::web::Document& doc ) {
       emp::web::Document doc("emp_base");
 
       SampleConfig cfg;
-      emp::prefab::ConfigPanel config_panel(cfg);
 
       int main(){
         // apply configuration query params and config files to SampleConfig
@@ -58,13 +53,12 @@ void config_panel_example( emp::web::Document& doc ) {
         am.UseCallbacks();
         if (am.HasUnused()) std::exit(EXIT_FAILURE);
 
-        // setup configuration panel
-        config_panel.Setup();
-        doc << config_panel.GetConfigPanelDiv();
+        emp::prefab::ConfigPanel config_panel(cfg);
+        doc << config_panel;
       }
     )";
 
   emp::prefab::CodeBlock cp_code_block(cp_code, "c++");
-  config_panel_ex.AddBodyContent(cp_code_block);
+  config_panel_ex << cp_code_block;
 
 }

--- a/source/font_awesome_icon_example.hpp
+++ b/source/font_awesome_icon_example.hpp
@@ -14,10 +14,10 @@ void font_awesome_icon_example( emp::web::Document& doc ) {
   emp::prefab::Card fa_icon_ex("INIT_CLOSED");
   doc << fa_icon_ex;
   fa_icon_ex.AddHeaderContent("<h3>FontAwesome Icon</h3>");
-  fa_icon_ex.AddBodyContent("<h3>Live Demo:</h3><hr>");
+  fa_icon_ex << "<h3>Live Demo:</h3><hr>";
 
   emp::web::Div toggleIcons;
-  fa_icon_ex.AddBodyContent(toggleIcons);
+  fa_icon_ex << toggleIcons;
   emp::prefab::FontAwesomeIcon check("fa-check-square-o");
   toggleIcons << check;
   emp::prefab::FontAwesomeIcon dots("fa-ellipsis-v");
@@ -31,9 +31,9 @@ void font_awesome_icon_example( emp::web::Document& doc ) {
   code.SetCSS("margin-left", "15px");
   up.SetCSS("margin-left", "15px");
 
-  fa_icon_ex.AddBodyContent("<br>More icons <a href=\"https://fontawesome.com/v4.7.0/icons/\" target=\"_blank\">here</a><br>");
+  fa_icon_ex << "<br>More icons <a href=\"https://fontawesome.com/v4.7.0/icons/\" target=\"_blank\">here</a><br>";
 
-  fa_icon_ex.AddBodyContent("<br><br><h3>Code:</h3><hr>");
+  fa_icon_ex << "<br><br><h3>Code:</h3><hr>";
 
   const std::string icon_code =
     R"(
@@ -64,13 +64,13 @@ void font_awesome_icon_example( emp::web::Document& doc ) {
     )";
 
   emp::prefab::CodeBlock icon_code_block(icon_code, "c++");
-  fa_icon_ex.AddBodyContent(icon_code_block);
-  fa_icon_ex.AddBodyContent("<p>Add to HTML file</p>");
+  fa_icon_ex << icon_code_block;
+  fa_icon_ex << "<p>Add to HTML file</p>";
   const std::string icon_html =
     R"(
       <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
     )";
   emp::prefab::CodeBlock icon_html_block(icon_html, "html");
-  fa_icon_ex.AddBodyContent(icon_html_block);
+  fa_icon_ex << icon_html_block;
 
 }

--- a/source/loading_icon_example.hpp
+++ b/source/loading_icon_example.hpp
@@ -15,11 +15,11 @@ void loading_icon_example( emp::web::Document& doc ) {
   emp::prefab::Card loading_icon_ex("INIT_CLOSED");
   doc << loading_icon_ex;
   loading_icon_ex.AddHeaderContent("<h3>Loading Icon</h3>");
-  loading_icon_ex.AddBodyContent("<h3>Live Demo:</h3><hr>");
+  loading_icon_ex << "<h3>Live Demo:</h3><hr>";
   emp::prefab::LoadingIcon spinner;
-  loading_icon_ex.AddBodyContent(spinner);
+  loading_icon_ex << spinner;
 
-  loading_icon_ex.AddBodyContent("<br><br><h3>Code:</h3><hr>");
+  loading_icon_ex << ("<br><br><h3>Code:</h3><hr>");
   const std::string loading_code =
     R"(
       #include "emp/prefab/LoadingIcon.hpp"
@@ -33,6 +33,6 @@ void loading_icon_example( emp::web::Document& doc ) {
       }
     )";
   emp::prefab::CodeBlock loading_code_block(loading_code, "c++");
-  loading_icon_ex.AddBodyContent(loading_code_block);
+  loading_icon_ex << loading_code_block;
 
 }

--- a/source/loading_modal_example.hpp
+++ b/source/loading_modal_example.hpp
@@ -15,16 +15,16 @@ void loading_modal_example( emp::web::Document& doc ) {
   emp::prefab::Card loading_modal_ex("INIT_CLOSED");
   doc << loading_modal_ex;
   loading_modal_ex.AddHeaderContent("<h3>Loading Modal</h3>");
-  loading_modal_ex.AddBodyContent("<h3>Live Demo:</h3><hr>");
+  loading_modal_ex << "<h3>Live Demo:</h3><hr>";
 
-  loading_modal_ex.AddBodyContent("<p>Click button to show loading modal. It will close automatically after a few seconds.</p>");
+  loading_modal_ex << "<p>Click button to show loading modal. It will close automatically after a few seconds.</p>";
   emp::web::Button loading_modal_demo([](){emscripten_run_script("DemoLoadingModal();");}, "Show Loading Modal");
-  loading_modal_ex.AddBodyContent(loading_modal_demo);
+  loading_modal_ex << loading_modal_demo;
   loading_modal_demo.SetAttr(
     "class", "btn btn-info"
   );
 
-  loading_modal_ex.AddBodyContent("<br><br><br><h3>Code:</h3><hr>");
+  loading_modal_ex << "<br><br><br><h3>Code:</h3><hr>";
   const std::string loading_modal_code =
     R"(
       #include "emp/prefab/LoadingModal.hpp"
@@ -39,8 +39,8 @@ void loading_modal_example( emp::web::Document& doc ) {
       }
     )";
   emp::prefab::CodeBlock loading_modal_code_block(loading_modal_code, "c++");
-  loading_modal_ex.AddBodyContent(loading_modal_code_block);
-  loading_modal_ex.AddBodyContent("<p>Add Loading Modal script at the top of the body section of your HTML file.</p>");
+  loading_modal_ex << loading_modal_code_block;
+  loading_modal_ex << "<p>Add Loading Modal script at the top of the body section of your HTML file.</p>";
   const std::string loading_modal_html =
     R"(
       <html>
@@ -59,6 +59,6 @@ void loading_modal_example( emp::web::Document& doc ) {
       </html>
     )";
   emp::prefab::CodeBlock loading_modal_code_block_html(loading_modal_html, "html");
-  loading_modal_ex.AddBodyContent(loading_modal_code_block_html);
+  loading_modal_ex << loading_modal_code_block_html;
 
 }

--- a/source/modal_example.hpp
+++ b/source/modal_example.hpp
@@ -16,12 +16,12 @@ void modal_example( emp::web::Document& doc ) {
   emp::prefab::Card modal_ex("INIT_CLOSED");
   doc << modal_ex;
   modal_ex.AddHeaderContent("<h3>Modal</h3>");
-  modal_ex.AddBodyContent("<h3>Live Demo:</h3><hr>");
+  modal_ex << "<h3>Live Demo:</h3><hr>";
   emp::prefab::Modal modal;
-  modal_ex.AddBodyContent(modal);
+  modal_ex << modal;
 
   modal.AddHeaderContent("<h3>Modal Header Section</h3>");
-  modal.AddBodyContent("This is the content of the modal");
+  modal << "This is the content of the modal";
 
   modal.AddFooterContent("Modal Footer Section");
   emp::web::Button close_btn([](){;}, "Close");
@@ -32,11 +32,11 @@ void modal_example( emp::web::Document& doc ) {
   modal.AddClosingX();
 
   emp::web::Button modal_btn([](){;}, "Show Modal");
-  modal_ex.AddBodyContent(modal_btn);
+  modal_ex << (modal_btn);
   modal_btn.SetAttr("class", "btn btn-info");
   modal.AddButton(modal_btn);
 
-  modal_ex.AddBodyContent("<br><br><br><h3>Code:</h3><hr>");
+  modal_ex << "<br><br><br><h3>Code:</h3><hr>";
   const std::string modal_code =
     R"(
       #include "emp/prefab/Modal.hpp"
@@ -50,7 +50,7 @@ void modal_example( emp::web::Document& doc ) {
         doc << modal;
 
         modal.AddHeaderContent("<h3>Modal Header Section</h3>");
-        modal.AddBodyContent("This is the content of the modal");
+        modal << ("This is the content of the modal");
 
         modal.AddFooterContent("Modal Footer Section");
         emp::web::Button close_btn([](){;}, "Close");
@@ -67,6 +67,6 @@ void modal_example( emp::web::Document& doc ) {
       }
     )";
   emp::prefab::CodeBlock modal_code_block(modal_code, "c++");
-  modal_ex.AddBodyContent(modal_code_block);
+  modal_ex << modal_code_block;
 
 }

--- a/source/readout_panel_example.hpp
+++ b/source/readout_panel_example.hpp
@@ -32,7 +32,10 @@ void readout_panel_example( emp::web::Document& doc ) {
   );
 
   readout_panel_ex << values;
-  readout_panel_ex << UI::Button([](){ ++counter; }, "Add one to counter");
+  emp::web::Button adder([](){ ++counter; }, "Add one to counter");
+  adder.SetAttr("class", "btn btn-primary");
+  readout_panel_ex << adder;
+  readout_panel_ex << "<br><br><h3>Code:</h3><hr>";
 
   const std::string readout_panel_code =
     R"(
@@ -60,8 +63,9 @@ void readout_panel_example( emp::web::Document& doc ) {
         );
 
         doc << values;
-        doc << emp::web::Button([](){ ++counter; }, "Add one to counter");
-
+        emp::web::Button adder([](){ ++counter; }, "Add one to counter")
+        adder.SetAttr("class", "btn");
+        readout_panel_ex << adder;
       }
     )";
 

--- a/source/readout_panel_example.hpp
+++ b/source/readout_panel_example.hpp
@@ -16,13 +16,14 @@ void readout_panel_example( emp::web::Document& doc ) {
   // ------ Readout Panel Example ------
   emp::prefab::Card readout_panel_ex("INIT_CLOSED");
   doc << readout_panel_ex;
-  readout_panel_ex.AddHeaderContent("<h3>Readout Panel</h1");
+  readout_panel_ex.AddHeaderContent("<h3>Readout Panel</h3>");
   readout_panel_ex << "<h3>Live Demo:</h3><hr>";
 
-  emp::prefab::ReadoutPanel values("Readout Values", 100); // Refreshes 10 times a second
+  // Refresh values every 100 milliseconds
+  emp::prefab::ReadoutPanel values("Readout Values", 100);
 
   // A random number generator
-  std::function<std::string()> random_number = [=]() mutable {
+  std::function<std::string()> random_number = [](){
     static emp::Random rand;
     return emp::to_string(rand.GetUInt());
   };
@@ -49,8 +50,8 @@ void readout_panel_example( emp::web::Document& doc ) {
       int counter = 0;
 
       int main() {
-
-        emp::prefab::ReadoutPanel values("Readout Values", 100); // Refreshes 10 times a second
+        // Refresh values every 100 milliseconds
+        emp::prefab::ReadoutPanel values("Readout Values", 100);
 
         std::function<std::string()> random_number = [=]() mutable {
           static emp::Random rand;

--- a/source/readout_panel_example.hpp
+++ b/source/readout_panel_example.hpp
@@ -26,7 +26,7 @@ void readout_panel_example( emp::web::Document& doc ) {
     static emp::Random rand;
     return emp::to_string(rand.GetUInt());
   };
-  values.AddValue(
+  values.AddValues(
     "Random", "A randomly generated number", random_number,
     "Counter", "How many times you've clicked the button", counter
   );
@@ -57,7 +57,7 @@ void readout_panel_example( emp::web::Document& doc ) {
           return emp::to_string(rand.GetUInt());
         };
 
-        values.AddValue(
+        values.AddValues(
           "Random", "A randomly generated number", random_number,
           "Counter", "How many times you've clicked the button", counter
         );

--- a/source/readout_panel_example.hpp
+++ b/source/readout_panel_example.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <string>
+
+#include "emp/math/Random.hpp"
+#include "emp/prefab/Card.hpp"
+#include "emp/prefab/CodeBlock.hpp"
+#include "emp/prefab/ReadoutPanel.hpp"
+#include "emp/web/Button.hpp"
+#include "emp/web/Document.hpp"
+
+int counter = 0;
+
+void readout_panel_example( emp::web::Document& doc ) {
+
+  // ------ Readout Panel Example ------
+  emp::prefab::Card readout_panel_ex("INIT_CLOSED");
+  doc << readout_panel_ex;
+  readout_panel_ex.AddHeaderContent("<h3>Readout Panel</h1");
+  readout_panel_ex << "<h3>Live Demo:</h3><hr>";
+
+  emp::prefab::ReadoutPanel values("Readout Values", 100); // Refreshes 10 times a second
+
+  // A random number generator
+  std::function<std::string()> random_number = [=]() mutable {
+    static emp::Random rand;
+    return emp::to_string(rand.GetUInt());
+  };
+  values.AddValue(
+    "Random", "A randomly generated number", random_number,
+    "Counter", "How many times you've clicked the button", counter
+  );
+
+  readout_panel_ex << values;
+  readout_panel_ex << UI::Button([](){ ++counter; }, "Add one to counter");
+
+  const std::string readout_panel_code =
+    R"(
+      #include "emp/math/Random.hpp"
+      #include "emp/prefab/Card.hpp"
+      #include "emp/prefab/ReadoutPanel.hpp"
+      #include "emp/web/web.hpp"
+      #include "emp/web/Button.hpp"
+
+      emp::web::Document doc("emp_base");
+      int counter = 0;
+
+      int main() {
+
+        emp::prefab::ReadoutPanel values("Readout Values", 100); // Refreshes 10 times a second
+
+        std::function<std::string()> random_number = [=]() mutable {
+          static emp::Random rand;
+          return emp::to_string(rand.GetUInt());
+        };
+
+        values.AddValue(
+          "Random", "A randomly generated number", random_number,
+          "Counter", "How many times you've clicked the button", counter
+        );
+
+        doc << values;
+        doc << emp::web::Button([](){ ++counter; }, "Add one to counter");
+
+      }
+    )";
+
+  emp::prefab::CodeBlock readout_panel_code_block(readout_panel_code, "c++");
+  readout_panel_ex << readout_panel_code_block;
+}

--- a/source/readout_panel_example.hpp
+++ b/source/readout_panel_example.hpp
@@ -65,7 +65,7 @@ void readout_panel_example( emp::web::Document& doc ) {
         doc << values;
         emp::web::Button adder([](){ ++counter; }, "Add one to counter")
         adder.SetAttr("class", "btn");
-        readout_panel_ex << adder;
+        doc << adder;
       }
     )";
 

--- a/source/readout_panel_example.hpp
+++ b/source/readout_panel_example.hpp
@@ -53,7 +53,7 @@ void readout_panel_example( emp::web::Document& doc ) {
         // Refresh values every 100 milliseconds
         emp::prefab::ReadoutPanel values("Readout Values", 100);
 
-        std::function<std::string()> random_number = [=]() mutable {
+        std::function<std::string()> random_number = [](){
           static emp::Random rand;
           return emp::to_string(rand.GetUInt());
         };

--- a/source/toggle_switch_example.hpp
+++ b/source/toggle_switch_example.hpp
@@ -13,27 +13,27 @@ void toggle_switch_example(emp::web::Document& doc ) {
   emp::prefab::Card toggle_switch_ex("INIT_CLOSED");
   doc << toggle_switch_ex;
   toggle_switch_ex.AddHeaderContent("<h3>Toggle Switch</h3>");
-  toggle_switch_ex.AddBodyContent("<h3>Live Demo:</h3><hr>");
+  toggle_switch_ex << "<h3>Live Demo:</h3><hr>";
 
   emp::prefab::ToggleSwitch on_switch(
     [](std::string val){ std::cout << "callback " << val << std::endl; },
     "Switch Defult On",
     true
   );
-  toggle_switch_ex.AddBodyContent(on_switch);
+  toggle_switch_ex << on_switch;
 
-  toggle_switch_ex.AddBodyContent("<br>");
+  toggle_switch_ex << "<br>";
 
   emp::prefab::ToggleSwitch off_switch(
     [](std::string val){ std::cout << "callback " << val << std::endl; },
     "",
     false
   );
-  toggle_switch_ex.AddBodyContent(off_switch);
+  toggle_switch_ex << off_switch;
 
   off_switch.AddLabel("Switch Defult Off");
 
-  toggle_switch_ex.AddBodyContent("<br><br><br><h3>Code:</h3><hr>");
+  toggle_switch_ex << "<br><br><br><h3>Code:</h3><hr>";
 
   const std::string toggle_code =
     R"(
@@ -64,6 +64,6 @@ void toggle_switch_example(emp::web::Document& doc ) {
     )";
 
   emp::prefab::CodeBlock toggle_code_block(toggle_code, "c++");
-  toggle_switch_ex.AddBodyContent(toggle_code_block);
+  toggle_switch_ex << toggle_code_block;
 
 }

--- a/source/web/empirical-prefab-demo-web.cpp
+++ b/source/web/empirical-prefab-demo-web.cpp
@@ -20,6 +20,7 @@
 #include "../font_awesome_icon_example.hpp"
 #include "../loading_icon_example.hpp"
 #include "../modal_example.hpp"
+#include "../readout_panel_example.hpp"
 #include "../toggle_switch_example.hpp"
 
 emp::web::Document doc("emp_base");
@@ -38,6 +39,8 @@ int main() {
   font_awesome_icon_example( doc );
   loading_icon_example( doc );
   modal_example( doc );
+  modal_example( doc );
+  readout_panel_example( doc );
   toggle_switch_example( doc );
 
   emp::prefab::CloseLoadingModal();

--- a/source/web/empirical-prefab-demo-web.cpp
+++ b/source/web/empirical-prefab-demo-web.cpp
@@ -39,7 +39,6 @@ int main() {
   font_awesome_icon_example( doc );
   loading_icon_example( doc );
   modal_example( doc );
-  modal_example( doc );
   readout_panel_example( doc );
   toggle_switch_example( doc );
 


### PR DESCRIPTION
Here's an example of the `ReadoutPanel` in action with the two main ways of creating live variables. To be merged only after the `readout-panel` branch is merged to master in Empirical.